### PR TITLE
feat: add bot activity 'Playing Spreading Democracy'

### DIFF
--- a/src/events/ready/console-log.js
+++ b/src/events/ready/console-log.js
@@ -1,3 +1,10 @@
-module.exports = (client) => {
-  console.log(`✅ ${client.user.tag} is online!`);
+const { ActivityType } = require('discord.js');
+
+module.exports = (c, client) => {
+  console.log(`✅ ${c.user.tag} is online!`);
+
+  client.user.setActivity({
+    name: 'Spreading Democracy',
+    type: ActivityType.Playing,
+  });
 };


### PR DESCRIPTION
This pull request includes a change to the `src/events/ready/console-log.js` file to enhance the functionality of logging and setting the user activity status when the client becomes ready.

The most important change includes:

* [`src/events/ready/console-log.js`](diffhunk://#diff-3d61cf2bb79566a62ee2e6c79d72d304e17cd69aa72b7def0c055b11e773a9a9L1-R9): Modified the function to require `ActivityType` from `discord.js` and added code to set the client's activity status to "Spreading Democracy" with the type `Playing`.