### PR TITLE
feat: add /superstore command to fetch Helldivers 2 store rotation

### DIFF
--- a/src/commands/superstore.js
+++ b/src/commands/superstore.js
@@ -1,0 +1,103 @@
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  EmbedBuilder,
+} = require('discord.js');
+
+const slotIcons = {
+  Head: '<:helmet:1340369850031276092>',
+  Body: '<:body:1340369834533326930>',
+};
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('superstore')
+    .setDescription('Get the current Superstore rotation.'),
+  run: async ({ interaction }) => {
+    await interaction.deferReply({
+      flags: MessageFlags.Ephemeral,
+    });
+
+    try {
+      const response = await fetch(
+        `${process.env.DIVEHARDER_API_URL}/store_rotation`
+      );
+
+      if (!response.ok) {
+        throw new Error(`API returned ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (data.items.every((item) => item.name === 'Unmapped: NO STORE DATA')) {
+        await interaction.editReply({
+          content: 'No store data available at the moment.',
+        });
+        return;
+      }
+
+      const date = new Date(`${data.expire_time} GMT`);
+      const rotationTime = Math.floor(date / 1000);
+      const timeRemaining = rotationTime - Math.floor(Date.now() / 1000);
+      const warningIcon = timeRemaining < 86400 ? ':warning:' : '';
+
+      const embed = new EmbedBuilder()
+        .setTitle('Superstore Rotation')
+        .setDescription(`Rotate <t:${rotationTime}:R> ${warningIcon}`)
+        .setColor('3498db');
+
+      data.items.forEach((item, index) => {
+        const slotIcon = slotIcons[item.slot] || '';
+
+        const type = item.slot === 'Head' ? '' : `Type: **${item.type}**`;
+        const passive =
+          item.passive.name === 'Standard Issue'
+            ? ''
+            : `**${item.passive.name}**`;
+        const passiveDescription =
+          item.passive.description === 'No additional bonuses.'
+            ? ''
+            : `-# - ${item.passive.description}`;
+
+        const fieldValue = [
+          type,
+          `Slot: **${item.slot}** ${slotIcon}`,
+          `Armor: **${item.armor_rating}**`,
+          `Speed: **${item.speed}**`,
+          `Stamina Regen: **${item.stamina_regen}**`,
+          passive,
+          passiveDescription,
+        ]
+          .filter(Boolean)
+          .join('\n');
+
+        embed.addFields({
+          name: `${item.name} - ${item.store_cost} <:super_credits:1340358881146306563>`,
+          value: fieldValue,
+          inline: true,
+        });
+
+        if (index % 2 === 0) {
+          embed.addFields({
+            name: '\u2800',
+            value: '\u2800',
+            inline: true,
+          });
+        }
+      });
+
+      await interaction.editReply({
+        embeds: [embed],
+      });
+    } catch (error) {
+      console.error(`Error getting Superstore rotation: ${error.message}`);
+      await interaction.editReply({
+        content: 'Unable to fetch Superstore rotation. Please try again later.',
+      });
+    }
+  },
+  options: {
+    // devOnly: true,
+    // deleted: true,
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ new CommandKit({
   devUserIds: [process.env.USER_ID],
   devRoleIds: [process.env.ROLE_ID],
   eventsPath: `${__dirname}/events`,
+  commandsPath: `${__dirname}/commands`,
+  bulkRegister: true,
 });
 
 client.login(process.env.TOKEN);


### PR DESCRIPTION
This pull request introduces a new command to fetch and display the current Superstore rotation in a Discord bot and updates the command registration process. The most important changes include adding the `superstore` command and modifying the command registration configuration.

### New Command Addition:

* [`src/commands/superstore.js`](diffhunk://#diff-a8e2d51193ef13a58342925ca307313927bcd4bd2daa0958613527b72f203e6dR1-R103): Added a new command `superstore` that fetches the current Superstore rotation from an API and displays the data in an embedded message on Discord.

### Command Registration Update:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R15-R16): Updated the command registration configuration to include the `commandsPath` and enabled `bulkRegister` for easier command management.