### PR TITLE
Add newsfeed event using syncFromApi

### DIFF
--- a/src/events/ready/newsfeed.js
+++ b/src/events/ready/newsfeed.js
@@ -1,0 +1,26 @@
+const { syncFromApi } = require('../../utils/sync-from-api');
+
+module.exports = async (client) => {
+  await syncFromApi(
+    client,
+    'newsfeed_id',
+    'steam',
+    'last_newsfeeds',
+    (item) => {
+      const cleanMessage = item.content
+        .replace(/\[h1\](.*?)\[\/h1\]/g, '# $1')
+        .replace(/\[h2\](.*?)\[\/h2\]/g, '## $1')
+        .replace(/\[b\](.*?)\[\/b\]/g, '**$1**')
+        .replace(/\[list\]/g, '')
+        .replace(/\[\/list\]/g, '')
+        .replace(/\[\*\]/g, '- ');
+
+      return {
+        title: item.title,
+        description: cleanMessage,
+        url: item.url,
+        color: '607d8b',
+      };
+    }
+  );
+};


### PR DESCRIPTION
This pull request adds a new feature to the `src/events/ready/newsfeed.js` file. The feature involves synchronizing newsfeed data from an API and formatting the content for better readability.

Key changes include:

* [`src/events/ready/newsfeed.js`](diffhunk://#diff-157a3c39449e9651c887fa76d5e628becba9061cfba1a9a954b5b96a33b8340dR1-R26): Added a new module that uses the `syncFromApi` utility function to fetch and format newsfeed data. The content is cleaned up by replacing specific tags with Markdown equivalents, and then structured into an object with `title`, `description`, `url`, and `color` properties.