### PR TITLE
feat: add start-interval.js to manage API sync intervals

### DIFF
--- a/src/events/ready/start-intervals.js
+++ b/src/events/ready/start-intervals.js
@@ -1,0 +1,5 @@
+const { startIntervals } = require('../../utils/intervals');
+
+module.exports = (client) => {
+  startIntervals(client);
+};


### PR DESCRIPTION
This pull request includes a new feature to start intervals when the client is ready. 

* [`src/events/ready/start-intervals.js`](diffhunk://#diff-f6c1f37e5c7b929b00b2a2326f15f885cf65263288d28b752172193be19c6832R1-R5): Added a new module to start intervals by importing the `startIntervals` function from `../../utils/intervals` and invoking it with the `client` parameter.