### PR TITLE
refactor: create lib/ folder and move dispatches, newsfeed, intervals…

### DIFF
--- a/src/events/ready/start-intervals.js
+++ b/src/events/ready/start-intervals.js
@@ -1,4 +1,4 @@
-const { startIntervals } = require('../../utils/intervals');
+const { startIntervals } = require('../../lib/intervals');
 
 module.exports = (client) => {
   startIntervals(client);

--- a/src/lib/dispatches.js
+++ b/src/lib/dispatches.js
@@ -1,4 +1,4 @@
-const { syncFromApi } = require('../../utils/sync-from-api');
+const { syncFromApi } = require('./sync-from-api');
 
 module.exports = async (client) => {
   await syncFromApi(

--- a/src/lib/intervals.js
+++ b/src/lib/intervals.js
@@ -1,19 +1,10 @@
-const dispatches = require('../events/ready/dispatches');
-const newsfeed = require('../events/ready/newsfeed');
-
-let isFirstRun = {
-  dispatches: true,
-  newsfeed: true,
-};
+const dispatches = require('./dispatches');
+const newsfeed = require('./newsfeed');
 
 const scheduleDispatches = async (client) => {
   console.log(`📡 Dispatches triggered at ${new Date().toLocaleTimeString()}`);
   try {
-    if (isFirstRun.dispatches) {
-      isFirstRun.dispatches = false;
-    } else {
-      await dispatches(client);
-    }
+    await dispatches(client);
   } catch (error) {
     console.error(`❌ Error in dispatches: ${error.message}`);
   }
@@ -23,11 +14,7 @@ const scheduleDispatches = async (client) => {
 const scheduleNewsfeed = async (client) => {
   console.log(`📢 Newsfeed triggered at ${new Date().toLocaleTimeString()}`);
   try {
-    if (isFirstRun.newsfeed) {
-      isFirstRun.newsfeed = false;
-    } else {
-      await newsfeed(client);
-    }
+    await newsfeed(client);
   } catch (error) {
     console.error(`❌ Error in newsfeed: ${error.message}`);
   }

--- a/src/lib/newsfeed.js
+++ b/src/lib/newsfeed.js
@@ -1,4 +1,4 @@
-const { syncFromApi } = require('../../utils/sync-from-api');
+const { syncFromApi } = require('./sync-from-api');
 
 module.exports = async (client) => {
   await syncFromApi(

--- a/src/lib/sync-from-api.js
+++ b/src/lib/sync-from-api.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const { EmbedBuilder } = require('discord.js');
-const pool = require('./db');
+const pool = require('../utils/db');
 
 const syncFromApi = async (client, idColumn, endpoint, dbTable, formatData) => {
   let lastId = null;
@@ -21,9 +21,13 @@ const syncFromApi = async (client, idColumn, endpoint, dbTable, formatData) => {
 
   const saveLastId = async (id) => {
     try {
-      await pool.query(`INSERT INTO ${dbTable} (${idColumn}) VALUES ($1)`, [
-        id,
-      ]);
+      await pool.query(
+        `INSERT INTO ${dbTable} (id, ${idColumn}, updated_at)
+         VALUES (1, $1, NOW())
+         ON CONFLICT (id) 
+         DO UPDATE SET ${idColumn} = EXCLUDED.${idColumn}, updated_at = NOW()`,
+        [id]
+      );
     } catch (error) {
       console.error(`Error saving ${idColumn}: ${error.message}`);
     }


### PR DESCRIPTION
This pull request involves several refactorings and improvements to the codebase, primarily focusing on renaming files and updating their references. Additionally, there are some changes to the database query logic to handle conflicts more gracefully.

Refactoring and file renaming:

* [`src/events/ready/start-intervals.js`](diffhunk://#diff-f6c1f37e5c7b929b00b2a2326f15f885cf65263288d28b752172193be19c6832L1-R1): Updated the import path for `startIntervals` from `../../utils/intervals` to `../../lib/intervals`.
* `src/lib/dispatches.js` (renamed from `src/events/ready/dispatches.js`): Updated the import path for `syncFromApi` from `../../utils/sync-from-api` to `./sync-from-api`.
* `src/lib/intervals.js` (renamed from `src/utils/intervals.js`): Updated the import paths for `dispatches` and `newsfeed` from `../events/ready/dispatches` and `../events/ready/newsfeed` to `./dispatches` and `./newsfeed`, respectively. Removed the `isFirstRun` logic for `dispatches` and `newsfeed`. [[1]](diffhunk://#diff-fab8c839fa27340c54c2bffa86f222cae4e9f81afeb8c584fe0199bee7778b22L1-L16) [[2]](diffhunk://#diff-fab8c839fa27340c54c2bffa86f222cae4e9f81afeb8c584fe0199bee7778b22L26-L30)
* `src/lib/newsfeed.js` (renamed from `src/events/ready/newsfeed.js`): Updated the import path for `syncFromApi` from `../../utils/sync-from-api` to `./sync-from-api`.
* `src/lib/sync-from-api.js` (renamed from `src/utils/sync-from-api.js`): Updated the import path for `pool` from `./db` to `../utils/db`. Modified the `saveLastId` function to handle conflicts by updating the existing record instead of inserting a new one. [[1]](diffhunk://#diff-c730bc260be9ef4ba91823b7bdc0168ddc769571cd520f0a24c1966543efb217L3-R3) [[2]](diffhunk://#diff-c730bc260be9ef4ba91823b7bdc0168ddc769571cd520f0a24c1966543efb217L24-R30)… and sync-from-api into it