### PR TITLE
feat: add schedulePlanets to execute planets

### DIFF
--- a/src/lib/intervals.js
+++ b/src/lib/intervals.js
@@ -1,6 +1,7 @@
 const dispatches = require('./dispatches');
 const newsfeeds = require('./newsfeeds');
 const campaigns = require('./campaigns');
+const planets = require('./planets');
 
 const scheduleDispatches = async (client) => {
   console.log(`📡 Dispatches triggered at ${new Date().toLocaleTimeString()}`);
@@ -9,7 +10,7 @@ const scheduleDispatches = async (client) => {
   } catch (error) {
     console.error(`❌ Error in dispatches: ${error.message}`);
   }
-  setTimeout(() => scheduleDispatches(client), 5 * 60 * 1000); // 5 minutes
+  setTimeout(() => scheduleDispatches(client), 10 * 60 * 1000); // 5 minutes
 };
 
 const scheduleNewsfeeds = async (client) => {
@@ -29,7 +30,17 @@ const scheduleCampaigns = async (client) => {
   } catch (error) {
     console.error(`❌ Error in newsfeed: ${error.message}`);
   }
-  setTimeout(() => scheduleCampaigns(client), 5 * 60 * 1000); // 5 minutes
+  setTimeout(() => scheduleCampaigns(client), 10 * 60 * 1000); // 10 minutes
+};
+
+const schedulePlanets = async (client) => {
+  console.log(`🪐 Planets triggered at ${new Date().toLocaleTimeString()}`);
+  try {
+    await planets(client);
+  } catch (error) {
+    console.error(`❌ Error in planets: ${error.message}`);
+  }
+  setTimeout(() => schedulePlanets(client), 10 * 60 * 1000); // 10 minutes
 };
 
 const startIntervals = (client) => {
@@ -37,6 +48,8 @@ const startIntervals = (client) => {
   scheduleDispatches(client);
   scheduleNewsfeeds(client);
   scheduleCampaigns(client);
+  schedulePlanets(client);
+  setTimeout(() => schedulePlanets(client), 200); // Start planets 200 ms after campaigns
 };
 
 module.exports = { startIntervals };


### PR DESCRIPTION
This pull request includes changes to the `src/lib/intervals.js` file to add a new scheduling function for planets and adjust the scheduling intervals for existing functions.

New functionality:

* Added a new `schedulePlanets` function to handle the scheduling of planet-related tasks.
* Updated the `startIntervals` function to include the `schedulePlanets` function and start it 200 ms after the campaigns.

Interval adjustments:

* Changed the interval for `scheduleDispatches` from 5 minutes to 10 minutes.
* Changed the interval for `scheduleCampaigns` from 5 minutes to 10 minutes.