### PR TITLE
fix: remove duplicate call to schedulePlanets in intervals.js

### DIFF
--- a/src/lib/intervals.js
+++ b/src/lib/intervals.js
@@ -48,7 +48,6 @@ const startIntervals = (client) => {
   scheduleDispatches(client);
   scheduleNewsfeeds(client);
   scheduleCampaigns(client);
-  schedulePlanets(client);
   setTimeout(() => schedulePlanets(client), 200); // Start planets 200 ms after campaigns
 };
 


### PR DESCRIPTION
This pull request includes a fix to the `startIntervals` function in the `src/lib/intervals.js` file where the scheduling of the `schedulePlanets` function was called twice.

Changes made:

* [`src/lib/intervals.js`](diffhunk://#diff-fab8c839fa27340c54c2bffa86f222cae4e9f81afeb8c584fe0199bee7778b22L51): Removed the duplicate call to `schedulePlanets` and ensure it starts 200 ms after `scheduleCampaigns`.