### PR TITLE
fix: invert schedulePlanets and scheduleCampaigns order in intervals.js

### DIFF
--- a/src/lib/intervals.js
+++ b/src/lib/intervals.js
@@ -47,8 +47,8 @@ const startIntervals = (client) => {
   console.log('⏳ Intervals started');
   scheduleDispatches(client);
   scheduleNewsfeeds(client);
-  scheduleCampaigns(client);
-  setTimeout(() => schedulePlanets(client), 200); // Start planets 200 ms after campaigns
+  schedulePlanets(client);
+  setTimeout(() => scheduleCampaigns(client), 200); // Start campaigns 200 ms after planets
 };
 
 module.exports = { startIntervals };


### PR DESCRIPTION
This pull request includes a change to the scheduling order of tasks in the `startIntervals` function in `src/lib/intervals.js`. The most important change is the reordering of the `schedulePlanets` and `scheduleCampaigns` calls to ensure that planets are scheduled before campaigns.

Changes to task scheduling:

* [`src/lib/intervals.js`](diffhunk://#diff-fab8c839fa27340c54c2bffa86f222cae4e9f81afeb8c584fe0199bee7778b22L50-R51): Reordered the calls to `schedulePlanets` and `scheduleCampaigns` so that `schedulePlanets` is called first and `scheduleCampaigns` is called 200 ms after `schedulePlanets`.